### PR TITLE
Replace deprecated variable

### DIFF
--- a/local/systemd.sh
+++ b/local/systemd.sh
@@ -33,8 +33,8 @@ systemd_add_unit() {
 	belt_remote_exec <<-SCRIPT
 		source /tmp/belt/env.sh
 		source /tmp/belt/lib/systemd.sh
-		cp "$_BELT_ARCHIVE_EXTRACTED_PATH/$unit" "\$BELT_SYSTEMD_PATH/$_BELT_APP_NAME.service"
+		cp "$_BELT_ARCHIVE_EXTRACTED_PATH/$unit" "\$BELT_SYSTEMD_PATH/$_BELT_ARCHIVE_BASENAME.service"
 		systemd_reload
-		systemd_unit_enable "$_BELT_APP_NAME.service"
+		systemd_unit_enable "$_BELT_ARCHIVE_BASENAME.service"
 	SCRIPT
 }


### PR DESCRIPTION
The `$_BELT_APP_NAME` variable doesn't appear to be defined anywhere, and causes the function to create a nameless `.service`. The fix is to use `$_BELT_ARCHIVE_BASENAME` instead.