### PR TITLE
Add custom scp options

### DIFF
--- a/belt.sh
+++ b/belt.sh
@@ -64,7 +64,7 @@ belt_remote_upload() {
 	local source="$1"
 	local target="$2"
 
-	scp -P "$_BELT_SSH_PORT" -r "$source" "$_BELT_SSH_USER@$_BELT_SSH_HOST:$target" &>/dev/null \
+	scp "${BELT_SCP_OPTS[@]}" -P "$_BELT_SSH_PORT" -r "$source" "$_BELT_SSH_USER@$_BELT_SSH_HOST:$target" &>/dev/null \
 		|| belt_abort "remote upload failed"
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -12,8 +12,6 @@ BELT_TOOLBOX_TOOLS="$BELT_ENV_TOOLBOX_TOOLS"
 
 BELT_TOOLBOX_PATH="$BELT_PATH_PREFIX/belt/toolbox"
 
-BELT_SCP_OPTS="${BELT_SCP_OPTIONS}"
-
 bootstrap_abort() {
 	local msg="$1"
 	echo "belt: $msg"

--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,8 @@ BELT_TOOLBOX_TOOLS="$BELT_ENV_TOOLBOX_TOOLS"
 
 BELT_TOOLBOX_PATH="$BELT_PATH_PREFIX/belt/toolbox"
 
+BELT_SCP_OPTS="${BELT_SCP_OPTIONS}"
+
 bootstrap_abort() {
 	local msg="$1"
 	echo "belt: $msg"


### PR DESCRIPTION
With the release of macOS Venture the version of `scp` binary used by Belt to upload various assets such as toolbox, archives etc. has fundamentally changed. In Venture scp now requires SFTP support from the host to which we are uploading to.

This PR introduces a variable name `BELT_SCP_OPTS` that allows Mac users to switch to using legacy version of `scp`. This can be done by adding `BELT_SCP_OPTS=(-O)` at the top of their deployment script.

Reference from the man page for `scp`:

```
-O        Use the legacy SCP protocol for file transfers instead of the
             SFTP protocol.  Forcing the use of the SCP protocol may be
             necessary for servers that do not implement SFTP, for backwards-
             compatibility for particular filename wildcard patterns and for
             expanding paths with a ‘~’ prefix for older SFTP servers.
```